### PR TITLE
Update metadataInstructions.ts to use V2 Instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
     "@metaplex-foundation/js": "^0.18.3",
-    "@metaplex-foundation/mpl-token-metadata": "^2.8.6",
+    "@metaplex-foundation/mpl-token-metadata": "^2.13.0",
     "@metaplex/js": "^4.12.0",
     "@octokit/auth-basic": "^1.4.8",
     "@octokit/rest": "^19.0.3",

--- a/src/lib/metadataInstructions.ts
+++ b/src/lib/metadataInstructions.ts
@@ -1,6 +1,6 @@
 import {
-    createUpdateMetadataAccountInstruction,
-    UpdateMetadataAccountInstructionArgs,
+    createUpdateMetadataAccountV2Instruction,
+    UpdateMetadataAccountV2InstructionArgs,
     PROGRAM_ID,
 
     SetAndVerifyCollectionInstructionAccounts, SetAndVerifyCollectionStruct, setAndVerifyCollectionInstructionDiscriminator,
@@ -13,14 +13,15 @@ export const updateMetadataAuthorityIx = (newAuthority: PublicKey, currentAuthor
         metadata: metadataAccount,
         updateAuthority: currentAuthority,
     };
-    const instructionArgs: UpdateMetadataAccountInstructionArgs = {
-        updateMetadataAccountArgs: {
+    const instructionArgs: UpdateMetadataAccountV2InstructionArgs = {
+        updateMetadataAccountArgsV2: {
             data: null,
             primarySaleHappened: null,
             updateAuthority: newAuthority,
+            isMutable: null
         },
     };
-    return createUpdateMetadataAccountInstruction(accounts, instructionArgs, PROGRAM_ID);
+    return createUpdateMetadataAccountV2Instruction(accounts, instructionArgs, PROGRAM_ID);
 };
 
 // export const setAndVerifyCollectionIx = (collection: PublicKey, authority: PublicKey, metadataAccount: PublicKey) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,19 @@
     "@solana/spl-token" "^0.1.8"
     "@solana/web3.js" "^1.31.0"
 
+"@metaplex-foundation/mpl-token-metadata@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.13.0.tgz#ea498190ad4ed1d4c0b8218a72d03bd17a883d11"
+  integrity sha512-Fl/8I0L9rv4bKTV/RAl5YIbJe9SnQPInKvLz+xR1fEc4/VQkuCn3RPgypfUMEKWmCznzaw4sApDxy6CFS4qmJw==
+  dependencies:
+    "@metaplex-foundation/beet" "^0.7.1"
+    "@metaplex-foundation/beet-solana" "^0.4.0"
+    "@metaplex-foundation/cusper" "^0.0.2"
+    "@solana/spl-token" "^0.3.6"
+    "@solana/web3.js" "^1.66.2"
+    bn.js "^5.2.0"
+    debug "^4.3.4"
+
 "@metaplex-foundation/mpl-token-metadata@^2.8.6":
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.8.6.tgz#c4d7e88fd5ed723e27d74a8e3f1d0a9e20504cee"


### PR DESCRIPTION
Changed the metadataInstructions.ts to use the new V2 Instructions as old instructions have been deprecated. 