### PR TITLE
fix(execute): state-aware retry after confirmation timeout in per-instruction execute loop

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -392,19 +392,25 @@ class Menu{
                             const signed = await this.wallet.signTransaction(executeIxTx);
                             const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
                             console.log(`ix ${ixIndex} signature: ${txid}`);
-                            await this.api.connection.confirmTransaction(txid, "confirmed");
+                            await this.api.connection.confirmTransaction({signature: txid, blockhash, lastValidBlockHeight}, "confirmed");
                             await this.api.squads.getTransaction(tx.publicKey);
                         } catch (_e) {
-                            console.log("Error executing instruction, trying it again");
-                            await this.api.squads.getTransaction(tx.publicKey);
-                            const ix = await this.api.executeInstructionBuilder(tx.publicKey, ixPDA);
-                            const {blockhash, lastValidBlockHeight} = await this.api.connection.getLatestBlockhash();
-                            const executeIxTx = new Transaction({lastValidBlockHeight, blockhash, feePayer: this.wallet.publicKey});
-                            executeIxTx.add(additionalComputeBudgetInstruction, ix);
-                            const signed = await this.wallet.signTransaction(executeIxTx);
-                            const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
-                            console.log(`ix ${ixIndex} retry signature: ${txid}`);
-                            await this.api.connection.confirmTransaction(txid, "confirmed");
+                            // The confirmation may have failed (e.g. timeout) even though the
+                            // instruction landed on-chain, so check fresh state before retrying.
+                            const refreshed = await this.api.squads.getTransaction(tx.publicKey);
+                            if (refreshed.executedIndex >= ixIndex) {
+                                console.log(`ix ${ixIndex} landed on-chain despite the confirmation error, continuing`);
+                            } else {
+                                console.log("Error executing instruction, trying it again");
+                                const ix = await this.api.executeInstructionBuilder(tx.publicKey, ixPDA);
+                                const {blockhash, lastValidBlockHeight} = await this.api.connection.getLatestBlockhash();
+                                const executeIxTx = new Transaction({lastValidBlockHeight, blockhash, feePayer: this.wallet.publicKey});
+                                executeIxTx.add(additionalComputeBudgetInstruction, ix);
+                                const signed = await this.wallet.signTransaction(executeIxTx);
+                                const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
+                                console.log(`ix ${ixIndex} retry signature: ${txid}`);
+                                await this.api.connection.confirmTransaction({signature: txid, blockhash, lastValidBlockHeight}, "confirmed");
+                            }
                         }
                         await this.api.squads.getTransaction(tx.publicKey);
                         successfullyExecuted++;
@@ -431,6 +437,7 @@ class Menu{
                 console.log(`Executed ${successfullyExecuted} instructions`);
                 console.log(`Terminated remaining execution because of an error: ${JSON.stringify(e)}`);
                 const updatedTx = await this.api.squads.getTransaction(tx.publicKey);
+                console.log(`On-chain executedIndex: ${updatedTx.executedIndex} of ${updatedTx.instructionIndex} instructions`);
                 await continueInq();
                 return () => this.transaction(updatedTx, ms, txs);
             }


### PR DESCRIPTION
## Summary

In the per-instruction execute loop in `src/lib/menu.ts` (`transaction` method, `TX_ACTION.EXECUTE` branch), a thrown `confirmTransaction` (e.g. a WebSocket timeout) was treated as proof the instruction had not executed. If the instruction had actually landed on-chain, the catch block blindly rebuilt and resent the same instruction PDA; since the on-chain `executedIndex` had already advanced, the retry failed with `ConstraintSeeds`, the outer catch fired, and the CLI reported "Executed 0 instructions" even though real side effects had landed — leaving the operator with a misleading view of partial execution state.

This PR makes the retry path state-aware:

- On a confirmation error, the loop now refreshes the transaction account via `getTransaction` and checks `executedIndex`. If `executedIndex >= ixIndex`, the instruction is counted as landed progress and execution continues to the next instruction instead of resending a stale PDA. Only if the instruction genuinely has not executed is it rebuilt and resent (in which case the same PDA is still the correct next instruction).
- Both `confirmTransaction` calls in this loop now use the blockheight-based confirmation strategy (`{ signature, blockhash, lastValidBlockHeight }`) instead of the legacy signature-only timeout API.
- The outer error path now also prints the on-chain `executedIndex` (e.g. "On-chain executedIndex: N of M instructions") so partial execution is explicit to the operator.

The atomic execute branch (`else`) is intentionally untouched; it is covered by separate tickets.

Fixes MUL-783 — https://linear.app/sqds/issue/MUL-783

Finding: Apex Report — squads-cli SQUA1-14 (Medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)