### PR TITLE
fix(import): parse raw import with Transaction.from instead of Message.from

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -254,8 +254,11 @@ class Menu{
                 const txBuffer = anchor.utils.bytes.bs58.decode(rawIx);
                 clear();
                 this.header();
-                const rawTxMessage = anchor.web3.Message.from(txBuffer);
-                const populatedTx = anchor.web3.Transaction.populate(rawTxMessage);
+                // The pasted blob is a serialized wire transaction, which is prefixed
+                // with a signature array. Transaction.from strips the signatures before
+                // parsing the message; Message.from would reinterpret signature bytes as
+                // message header/instruction data, yielding different instructions.
+                const populatedTx = anchor.web3.Transaction.from(txBuffer);
                 const ixes = populatedTx.instructions;
                 console.log("This will create a new multisig transaction for authority/signer " + chalk.blue(authorityPDA.toBase58()));
                 const {yes} = await basicConfirm(`Create a transaction with ${ixes.length} instructions?`, false);


### PR DESCRIPTION
## Summary

The raw transaction import flow in `src/lib/menu.ts` (`createTransaction`, "Enter serialized transaction" branch) decoded the pasted base58 blob with `anchor.web3.Message.from(txBuffer)` followed by `Transaction.populate(...)`. A serialized wire transaction is prefixed with a compact array of signatures, and `Message.from` does not strip it — so the signature bytes were reinterpreted as message header and instruction data. A crafted base58 payload could therefore stage multisig instructions that differ from what the same blob represents as an actual wire transaction.

The fix parses the buffer with `anchor.web3.Transaction.from(txBuffer)`, which strips the leading signature array before decoding the message, so the staged instructions always match the pasted wire transaction. A comment documents why `Transaction.from` is required for wire-format input.

Fixes MUL-777 — https://linear.app/sqds/issue/MUL-777

Finding: Apex Report — squads-cli SQUA1-19 (High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)