### PR TITLE
fix(assets): stop dropping wrapped SOL from the vault asset table

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -34,10 +34,10 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
         name: "Solana",
     }];
 
-    // Exclude wrapped-SOL token accounts (the native SOL row already covers it).
-    const splAccounts = parsedAccount.value.filter(
-        a => a.account.data.parsed.info.mint !== WRAPPED_SOL_MINT
-    );
+    // Include wrapped-SOL token accounts — the native SOL row only reflects
+    // lamports from getBalance, so WSOL held in SPL token accounts must be
+    // listed separately or vault custody is understated.
+    const splAccounts = parsedAccount.value;
 
     if (splAccounts.length > 0) {
         const mints = splAccounts.map(a => new PublicKey(a.account.data.parsed.info.mint));
@@ -55,6 +55,18 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
             const decimals: number = acc.account.data.parsed.info.tokenAmount.decimals;
             const amount: number = acc.account.data.parsed.info.tokenAmount.uiAmount;
             const source = acc.pubkey.toBase58();
+
+            // Wrapped SOL: render explicitly so it is distinguishable from the
+            // native SOL row (and never hits the NFT heuristic or metadata lookup).
+            if (mintStr === WRAPPED_SOL_MINT) {
+                usableTokens.push({
+                    amount, source, mint: mintStr,
+                    symbol: 'wSOL',
+                    decimals,
+                    name: "Wrapped SOL",
+                });
+                return;
+            }
 
             // NFT heuristic: has an Edition account OR decimals === 0.
             const isNFT = editionAccounts[i] !== null || decimals === 0;


### PR DESCRIPTION
## Summary

`getAssets` in `src/lib/assets.ts` filtered out every wrapped-SOL token account on the assumption that the synthetic native-SOL row (built from `connection.getBalance`) already covered it. It did not: `getBalance` only reports native lamports, so WSOL held in SPL token accounts was silently dropped from the vault asset table. A vault holding 100 wrapped SOL but 0 native lamports displayed as holding 0 SOL, understating custody in the CLI's only asset inventory view.

This PR removes the WSOL filter so wrapped-SOL token accounts flow through the normal SPL rendering path, and special-cases them early in the per-account loop (before the NFT heuristic and metadata lookup) so they render as explicit `wSOL` / "Wrapped SOL" rows, clearly distinguishable from the native `SOL` row.

Fixes MUL-780 — https://linear.app/sqds/issue/MUL-780

Apex Report — squads-cli SQUA1-6 (Medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)