### PR TITLE
feat(menu): direct multisig open-by-address path (discovery spam mitigation)

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -154,11 +154,14 @@ class Menu{
             spinner.stop();
             const testList = await loadAuthorities(this.multisigs);
 
+            const oIndex = testList.length;
+            testList.push({ name: "Open multisig by address ->", value: oIndex, short: "Open by address" });
             const dIndex = testList.length;
             testList.push({ name: "<- Go back", value: dIndex, short: "Go back" });
 
             const {action} = await viewMultisigsMenu(testList, dIndex);
             if (action === dIndex) return () => this.top();
+            if (action === oIndex) return () => this.openMultisigByAddress();
             return () => this.multisig(this.multisigs[action]);
         } catch (error) {
             spinner.stop();
@@ -167,6 +170,49 @@ class Menu{
             await continueInq();
             return () => this.top();
         }
+    };
+
+    // Direct open-by-address path. Discovery (getSquads) can be spammed with
+    // permissionlessly created decoy multisigs that include this wallet, so
+    // operators need a way to reach a known multisig without relying on the
+    // discovered list.
+    private openMultisigByAddress = async (): Promise<NextAction> => {
+        const {address} = await inquirer.prompt({
+            type: "input",
+            name: "address",
+            message: "Enter the multisig account address (leave empty to go back):",
+        });
+        const trimmed = (address as string).trim();
+        if (trimmed.length < 1) return () => this.multisigList();
+
+        let msPDA: PublicKey;
+        try {
+            msPDA = new PublicKey(trimmed);
+        } catch (e) {
+            console.log(chalk.red("Invalid address - could not parse as a public key"));
+            await continueInq();
+            return () => this.multisigList();
+        }
+
+        const spinner = new Spinner("Loading multisig...");
+        spinner.start();
+        let msAccount: MultisigAccount;
+        try {
+            msAccount = await this.api.getSquadExtended(msPDA);
+        } catch (error) {
+            spinner.stop();
+            console.log(chalk.red(`No multisig account found at ${msPDA.toBase58()}`));
+            await continueInq();
+            return () => this.multisigList();
+        }
+        spinner.stop();
+
+        const isMember = msAccount.keys.some((k) => k.equals(this.wallet.publicKey));
+        if (!isMember) {
+            console.log(chalk.yellow("Warning: the connected wallet is NOT a member of this multisig."));
+            await continueInq();
+        }
+        return () => this.multisig(msAccount);
     };
 
     multisig = async (ms: MultisigAccount): Promise<NextAction> => {


### PR DESCRIPTION
## Summary

Apex Report — squads-cli SQUA1-1 (Medium)

Anyone can permissionlessly create Squads multisigs that include a victim's wallet in the member list. Since the CLI's only route to a multisig is the discovery-based "View my Multisigs" list (`multisigList` backed by `API.getSquads`), an attacker can bloat and poison that single review path with decoys, burying the operator's real governance objects.

This PR adds a direct open-by-address path that bypasses discovery entirely:

- A new `Open multisig by address ->` entry in the multisig list menu.
- Prompts for a base58 multisig account address, validates it parses as a `PublicKey`, and fetches it via `getSquadExtended` with a spinner; parse/fetch failures print an error and return to the list (empty input also returns to the list).
- If the connected wallet is not in the multisig's `keys`, a yellow warning is shown before proceeding to the multisig menu.

Capping or segregating discovery results (e.g. separating wallet-created vs. third-party-created multisigs) is a larger product decision and is intentionally left out of scope here.

Fixes MUL-785
Linear: https://linear.app/sqds/issue/MUL-785

🤖 Generated with [Claude Code](https://claude.com/claude-code)