### PR TITLE
fix(nft): write bulk authority-out logs to a temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bin/
 
 transfer.json
 yarn-error.log
+
+authority-out-*.txt
+authority-out-mints-*.json

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -6,6 +6,7 @@ import * as anchor from "@coral-xyz/anchor";
 import CLI from "clui";
 import "console.table";
 import * as fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { DEFAULT_MULTISIG_PROGRAM_ID, DEFAULT_PROGRAM_MANAGER_PROGRAM_ID, getIxPDA } from '@sqds/sdk';
@@ -986,9 +987,10 @@ class Menu{
             console.log("Creating the multisig transactions, this may take some time depending on the number of mints and your internet connection speed.");
             const status = new Spinner("Initializing metadata authority update multisig transactions...");
             status.start();
-            // setup log file
+            // setup log file in a fresh temp directory (avoid writing sensitive logs into cwd)
             const logtime = Date.now();
-            const logFilename = path.join(process.cwd(),`/authority-out-${logtime}.txt`);
+            const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'squads-authority-out-'));
+            const logFilename = path.join(logDir,`authority-out-${logtime}.txt`);
             const transferOutWriteStream = fs.createWriteStream(logFilename, "utf8");
             const fullResults = [];
             try {
@@ -1018,12 +1020,13 @@ class Menu{
                 transferOutWriteStream.close();
             }
             // write the json log file
-            const logFilenameJson = path.join(process.cwd(),`/authority-out-mints-${logtime}.json`);
+            const logFilenameJson = path.join(logDir,`authority-out-mints-${logtime}.json`);
             // write the successful fullResults to the logFilenameJson
             fs.writeFileSync(logFilenameJson, JSON.stringify(fullResults, null, 2));
             status.stop();
             console.log(`Finished staging authority transfer txs for ${successfullyStagedMetas.length} metadata accounts`);
             console.log(`Output logs written to: ${logFilename}`);
+            console.log(`Mint results written to: ${logFilenameJson}`);
             await continueInq();
         }
         return () => this.nfts(ms);


### PR DESCRIPTION
## Summary

The bulk NFT authority change helper (`nftAuthorityChangeOutgoing` in `src/lib/menu.ts`) wrote its two log files — `authority-out-<timestamp>.txt` and `authority-out-mints-<timestamp>.json` (containing the mint inventory, transaction PDA, and batch status) — directly into `process.cwd()`. Operators often run the CLI from a repo checkout or package root, and these patterns were not git-ignored or npm-ignored, so the files could leak into commits or published tarballs.

This change:
- Writes both log files into a fresh temp directory created with `fs.mkdtempSync(path.join(os.tmpdir(), 'squads-authority-out-'))` instead of the current working directory.
- Prints the path of the JSON results file in addition to the text log so operators can find both outputs.
- Adds `authority-out-*.txt` and `authority-out-mints-*.json` to `.gitignore` as defense in depth for files generated by older CLI versions in repo checkouts.

Fixes MUL-778 — https://linear.app/sqds/issue/MUL-778

Finding: Apex Report — squads-cli SQUA1-5 (Informational)

## Verification

`npx tsc --noEmit` passes with no new errors (only the pre-existing `src/lib/api.ts(40,59)` wallet type error remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)