### PR TITLE
fix(ux): helper prompts now disclose activate + auto-approve side effects

### DIFF
--- a/src/lib/inq/nftMenu.js
+++ b/src/lib/inq/nftMenu.js
@@ -71,7 +71,7 @@ export const nftUpdateAuthorityConfirmInq = (newAuthority, numMints, numTransact
         {
             type: 'confirm',
             name: 'confirm',
-            message: `Are you sure you want to change the authority of ${numMints} mints to ${newAuthority}? This will create ${numTransactions} transactions in the multisig.`,
+            message: `Are you sure you want to change the authority of ${numMints} mints to ${newAuthority}? This will create ${numTransactions} transactions in the multisig — each will be activated and your approval vote cast automatically.`,
         }
     ];
     return inquirer.prompt(questions);
@@ -93,7 +93,7 @@ export const nftWithdrawConfirmInq = (destination, numMints, numTransactions) =>
         {
             type: 'confirm',
             name: 'confirm',
-            message: `Are you sure you want to send ${numMints} NFTs to ${destination}? This will create ${numTransactions} transactions in the multisig.`,
+            message: `Are you sure you want to send ${numMints} NFTs to ${destination}? This will create ${numTransactions} transactions in the multisig — each will be activated and your approval vote cast automatically.`,
         }
     ];
     return inquirer.prompt(questions);

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -496,7 +496,7 @@ class Menu{
     addKey = async (ms: MultisigAccount): Promise<NextAction> => {
         const {memberKey} = await inquirer.prompt({default: "", name: 'memberKey', type: 'input', message: `Enter the public key of the member you want to add (base58):`});
         if (memberKey === "") return () => this.settings(ms);
-        const {yes} = await basicConfirm(`Create transaction to add ${memberKey}?`, false);
+        const {yes} = await basicConfirm(`Create, activate, and cast your approval on a transaction to add ${memberKey}?`, false);
         if (!yes) return () => this.addKey(ms);
         const newKey = new PublicKey(memberKey);
         const status = new Spinner("Creating New Member Transaction...");
@@ -504,7 +504,7 @@ class Menu{
         try {
             await this.api.addKeyTransaction(ms.publicKey, newKey);
             status.stop();
-            console.log("Transaction created!");
+            console.log("Transaction created and activated — your approval vote has been cast.");
             await continueInq();
             const newMs = await this.api.squads.getMultisig(ms.publicKey);
             return () => this.multisig(newMs);
@@ -522,7 +522,7 @@ class Menu{
         choices.push("<- Go back");
         const {memberKey} = await inquirer.prompt({choices, name: 'memberKey', type: 'list', message: `Which key do you want to remove?`});
         if (memberKey === "<- Go back") return () => this.settings(ms);
-        const {yes} = await basicConfirm(`Create transaction to remove ${memberKey}?`, false);
+        const {yes} = await basicConfirm(`Create, activate, and cast your approval on a transaction to remove ${memberKey}?`, false);
         if (!yes) return () => this.removeKey(ms);
         const status = new Spinner("Creating Remove Member Transaction...");
         status.start();
@@ -530,6 +530,7 @@ class Menu{
             const exKey = new PublicKey(memberKey);
             await this.api.removeKeyTransaction(ms.publicKey, exKey);
             status.stop();
+            console.log("Transaction created and activated — your approval vote has been cast.");
             const newMs = await this.api.squads.getMultisig(ms.publicKey);
             await continueInq();
             return () => this.multisig(newMs);
@@ -556,13 +557,14 @@ class Menu{
             },
         });
         if (threshold === "") return () => this.settings(ms);
-        const {yes} = await basicConfirm(`Create transaction to change threshold to ${threshold}?`, false);
+        const {yes} = await basicConfirm(`Create, activate, and cast your approval on a transaction to change threshold to ${threshold}?`, false);
         if (!yes) return () => this.settings(ms);
         const status = new Spinner("Creating Change Threshold Transaction...");
         status.start();
         try {
             await this.api.changeThresholdTransaction(ms.publicKey, threshold);
             status.stop();
+            console.log("Transaction created and activated — your approval vote has been cast.");
             const newMs = await this.api.squads.getMultisig(ms.publicKey);
             await continueInq();
             return () => this.multisig(newMs);
@@ -633,6 +635,7 @@ class Menu{
         const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         console.log(`This will create a safe upgrade authority transfer transaction of ${programId} ${destination.direction} the Squad vault`);
+        console.log("The transaction will also be activated and your approval vote cast automatically.");
         console.log("Program Address: " + chalk.blue(`${programId}`));
         console.log(`Multisig Address: ` + chalk.white(`${ms.publicKey.toBase58()}`));
         console.log(`Current Program Authority: ` + chalk.white(`${currentAuthority}`));
@@ -644,7 +647,7 @@ class Menu{
         try {
             const tx = await this.api.createSafeAuthorityTx(ms.publicKey, new PublicKey(programId), new PublicKey(currentAuthority), destination.key);
             status.stop();
-            console.log(chalk.green("Transaction created!"));
+            console.log(chalk.green("Transaction created and activated — your approval vote has been cast."));
             console.log(chalk.blue("Transaction ID: ") + chalk.white(tx));
             await continueInq();
             return () => this.multisig(ms);
@@ -783,6 +786,7 @@ class Menu{
         const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         console.log(`This will create a transaction for the transfer of the validator (${validatorId}) withdraw authority out of the Squad vault`);
+        console.log("The transaction will also be activated and your approval vote cast automatically.");
         console.log("Validator Address: " + chalk.blue(`${validatorId}`));
         console.log(`Withdraw Authority: ` + chalk.white(`${withdrawAuthority}`));
         console.log(`New Withdraw Authority: ` + chalk.white(`${destination}`));
@@ -793,7 +797,7 @@ class Menu{
         try {
             const tx = await this.api.createTransferWithdrawAuthTx(ms.publicKey, new PublicKey(validatorId), new PublicKey(withdrawAuthority), new PublicKey(destination));
             status.stop();
-            console.log(chalk.green("Transaction created!"));
+            console.log(chalk.green("Transaction created and activated — your approval vote has been cast."));
             console.log(chalk.blue("Transaction ID: ") + chalk.white(tx));
             await continueInq();
             return () => this.multisig(ms);


### PR DESCRIPTION
## Summary

Several helper flows (member add/remove, threshold change, program/validator authority transfers, and bulk NFT update-authority/withdraw) told the user they would only "create a transaction". In reality, the underlying helpers (`submitBuilderTx` / `submitAsMultisigTx` in `src/lib/api.ts`, and the NFT tx builders in `src/lib/nfts.ts`) also **activate** the transaction and **cast the operator's approval vote** — a real governance side effect the UI understated.

This PR updates the user-facing wording only (no behavior changes):

- `addKey`, `removeKey`, `changeThreshold` confirm prompts now read "Create, activate, and cast your approval on a transaction to ...", and success logs state the transaction was created and activated with the approval vote cast (logs added for the two flows that had none).
- `programAuthorityChange` and `transferWithdrawAuthorityOut` now print an extra line stating the transaction will also be activated and the connected wallet's approval vote cast automatically, with matching success messages.
- `nftUpdateAuthorityConfirmInq` and `nftWithdrawConfirmInq` bulk-NFT confirm prompts now state each staged transaction will be activated and the operator's approval cast.

Fixes MUL-774 — https://linear.app/sqds/issue/MUL-774
Finding: Apex Report — squads-cli SQUA1-4 (Low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)