### PR TITLE
fix(packaging): files allowlist + prepack rebuild of bin/

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "2.3.19",
   "description": "",
   "main": "bin/index.js",
+  "files": [
+    "bin/",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsc",
+    "prepack": "rm -rf bin && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.ts'",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import Squads, { getTxPDA, getAuthorityPDA } from "@sqds/sdk";
+import type { Wallet as SdkNodeWallet } from "@coral-xyz/anchor";
 import * as anchor from "@coral-xyz/anchor";
 import BN from "bn.js";
 import chalk from "chalk";
@@ -37,7 +38,13 @@ class API{
     constructor(wallet: AnchorWallet, connection: CliConnection, programId: PublicKey, programManagerId: PublicKey){
         this.programId = programId;
         this.programManagerId = programManagerId;
-        this.squads = Squads.endpoint(connection.cluster, wallet, {commitmentOrConfig: "confirmed", multisigProgramId: this.programId, programManagerProgramId: this.programManagerId});
+        // @sqds/sdk types this parameter as anchor's NodeWallet *class* (which
+        // requires a `payer` Keypair), but at runtime it only hands the wallet
+        // to AnchorProvider, which uses the Wallet *interface* members
+        // (publicKey/signTransaction/signAllTransactions). Ledger wallets
+        // implement the interface but have no `payer`, so we assert to the
+        // SDK's expected type. No runtime behavior change.
+        this.squads = Squads.endpoint(connection.cluster, wallet as SdkNodeWallet, {commitmentOrConfig: "confirmed", multisigProgramId: this.programId, programManagerProgramId: this.programManagerId});
         this.wallet = wallet;
         this.cluster = connection.cluster;
         this.connection = connection.connection;


### PR DESCRIPTION
## Summary

`package.json` ships `bin/index.js` as both `main` and the `squads-cli` executable, but `bin/` is git-ignored local build output (the tsc outDir) and `.npmignore` did not exclude it. `npm pack`/`npm publish` would therefore ship whatever untracked build output happened to sit in `bin/`, and any stray file in the working tree could leak into the tarball — breaking source-to-artifact trust for a governance CLI.

This PR closes that trust gap at the packaging layer:

- **`files` allowlist**: only `bin/`, `README.md`, and `CHANGELOG.md` are packed (npm always includes `package.json` and `LICENSE`). Stray working-tree files can no longer leak into the tarball; the allowlist takes precedence over `.npmignore`.
- **`prepack` script** (`rm -rf bin && npm run build`): every pack/publish discards stale local output and rebuilds `bin/` from tracked source, so the shipped artifact always corresponds to the checked-in code. `bin/` intentionally stays in `.gitignore` — it remains a build artifact; the prepack rebuild is the trust fix.
- **Pre-existing tsc error fixed** (`src/lib/api.ts:40`): `tsc` exited non-zero because `@sqds/sdk`'s `endpoint()` is typed against anchor's NodeWallet *class* (requires `payer`) while the CLI passes the anchor Wallet *interface* (Ledger wallets have no `payer`). Since the SDK only hands the wallet to `AnchorProvider` (interface members only), an explicit, commented type assertion is applied. No runtime behavior change. Without this, `prepack` would block packing entirely. `npx tsc --noEmit` now exits 0 with zero errors.

## Verification

`npm pack --dry-run`:
- `prepack` triggered and rebuilt `bin/` from source successfully (`rm -rf bin && tsc`).
- Tarball contents: `bin/**`, `CHANGELOG.md`, `LICENSE`, `README.md`, `package.json` — **81 files total**, no stray root files.

## Follow-up

CI provenance/attestation (e.g. `npm publish --provenance` from CI) is a follow-up beyond this repo change.

Fixes MUL-773
Linear: https://linear.app/sqds/issue/MUL-773
Finding: Apex Report — squads-cli SQUA1-2 (Informational)

🤖 Generated with [Claude Code](https://claude.com/claude-code)