### PR TITLE
fix(integers): check integers for authority

### DIFF
--- a/src/lib/inq/createTransaction.js
+++ b/src/lib/inq/createTransaction.js
@@ -9,8 +9,8 @@ const questions = [
         type: 'number',
         message: 'Enter the authority index to use (default 1):',
         validate: function( value ) {
-            if (value < 1 ) {
-                return 'Authorities must be greater than 0, if you need to change the multisig settings, use the settings menu';
+            if (!Number.isInteger(value) || value < 1) {
+                return 'Authority index must be a whole number greater than 0, if you need to change the multisig settings, use the settings menu';
             }else{
                 return true;
             }

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -227,14 +227,14 @@ class Menu{
 
         if (assemble.indexOf("Assemble") == 0) {
             const {authority} = await createTransactionInq();
-            const authorityPDA = await this.api.getAuthority(ms.publicKey, parseInt(authority, 10));
+            const authorityPDA = await this.api.getAuthority(ms.publicKey, authority);
 
             const status = new Spinner("Creating transaction...");
             console.log("This will create a new transaction draft for authority " + chalk.blue(authorityPDA.toBase58()));
             const {yes} = await basicConfirm("Continue?", false);
             if (!yes) return () => this.multisig(ms);
             status.start();
-            const tx = await this.api.createTransaction(ms.publicKey, parseInt(authority, 10));
+            const tx = await this.api.createTransaction(ms.publicKey, authority);
             status.stop();
             console.log("Transaction created!");
             console.log("Transaction key: " + chalk.blue(tx.publicKey.toBase58()));
@@ -244,7 +244,7 @@ class Menu{
         }
         if (assemble.indexOf("Enter") == 0) {
             const {authority} = await createTransactionInq();
-            const authorityPDA = await this.api.getAuthority(ms.publicKey, parseInt(authority, 10));
+            const authorityPDA = await this.api.getAuthority(ms.publicKey, authority);
 
             const {rawIx} = await addTransactionInq();
             if (rawIx.length <= 1) return () => this.multisig(ms);
@@ -261,7 +261,7 @@ class Menu{
                 const {yes} = await basicConfirm(`Create a transaction with ${ixes.length} instructions?`, false);
                 if (!yes) return () => this.multisig(ms);
                 status.start();
-                const tx = await this.api.createTransaction(ms.publicKey, parseInt(authority, 10));
+                const tx = await this.api.createTransaction(ms.publicKey, authority);
                 status.stop();
                 console.log(`Transaction ${tx.publicKey.toBase58()} created!`);
                 for (let i = 0; i < ixes.length; i++) {


### PR DESCRIPTION
This pull request improves input validation for authority indices and simplifies the handling of the `authority` parameter in transaction creation flows. The most important changes are:

**Input Validation Improvements:**

* Updated the authority index prompt in `createTransaction.js` to require the input to be a whole number greater than 0, providing clearer feedback to the user.

**Parameter Handling Simplification:**

* Removed unnecessary `parseInt` conversions when passing the `authority` value to `getAuthority` and `createTransaction` methods in `menu.ts`, as the input is now validated to be an integer. [[1]](diffhunk://#diff-08a556ed1588676c982a85545749ee25cfdf219a908d85b76f3e863138ec9686L230-R237) [[2]](diffhunk://#diff-08a556ed1588676c982a85545749ee25cfdf219a908d85b76f3e863138ec9686L247-R247) [[3]](diffhunk://#diff-08a556ed1588676c982a85545749ee25cfdf219a908d85b76f3e863138ec9686L264-R264)