### PR TITLE
fix(confirmation): adjusted to confirmed for state change

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -416,14 +416,21 @@ class Menu{
                     executeTx.add(additionalComputeBudgetInstruction, ix);
                     const signed = await this.wallet.signTransaction(executeTx);
                     const txid = await this.api.connection.sendRawTransaction(signed.serialize());
-                    await this.api.connection.confirmTransaction(txid, "processed");
+                    // Wait for "confirmed" (not "processed") before reporting success:
+                    // single-instruction control changes (membership/threshold/authority
+                    // transfers) take this fast path, and processed state can disappear
+                    // on fork churn, making a governance change look durably complete
+                    // when it is not.
+                    await this.api.connection.confirmTransaction(txid, "confirmed");
                 }
                 status.stop();
-                const updatedTx = await this.api.squads.getTransaction(tx.publicKey);
+                // Re-read at "confirmed" so the success message and refreshed state
+                // reflect durable finality rather than the SDK's "processed" default.
+                const updatedTx = await this.api.squads.getTransaction(tx.publicKey, "confirmed");
                 const newInd = txs.findIndex(t => t.publicKey.toBase58() === tx.publicKey.toBase58());
                 txs.splice(newInd, 1, updatedTx);
                 console.log("Transaction executed");
-                const updatedMs = await this.api.squads.getMultisig(ms.publicKey);
+                const updatedMs = await this.api.squads.getMultisig(ms.publicKey, "confirmed");
                 await continueInq();
                 return () => this.transaction(updatedTx, updatedMs, txs);
             } catch (e) {


### PR DESCRIPTION
This pull request improves the reliability and durability of transaction state handling in the multisig execution flow by ensuring all transaction and multisig state reads occur at the "confirmed" commitment level, rather than the less durable "processed" level. This helps prevent scenarios where governance changes appear complete but are lost due to blockchain fork churn.

**Improvements to transaction confirmation and state consistency:**

* Changed all calls to `confirmTransaction`, `getTransaction`, and `getMultisig` in `src/lib/menu.ts` to use the `"confirmed"` commitment level instead of `"processed"`, ensuring that reported success and refreshed state reflect durable finality and cannot be lost on fork churn.