### PR TITLE
fix(authority-batches): fix for index check

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -380,7 +380,13 @@ class Menu{
                 units: EXECUTE_IX_COMPUTE_UNIT_LIMIT,
             });
             try {
-                if (tx.instructionIndex > 3) {
+                // The sequential executeInstruction path is rejected on-chain for
+                // authority-index 0 (internal/governance) transactions — the program
+                // returns InvalidAuthorityIndex (6004) and the batch stalls as
+                // executeReady forever. Such batches (created by other Squads clients
+                // or SDK scripts) must use the atomic executeTransaction path, so only
+                // route to the split path when the authority index is 1 or greater.
+                if (tx.authorityIndex >= 1 && tx.instructionIndex > 3) {
                     for (let ixIndex = tx.executedIndex + 1; ixIndex <= tx.instructionIndex; ixIndex++) {
                         const [ixPDA] = getIxPDA(tx.publicKey, new anchor.BN(ixIndex), this.api.programId);
                         console.log("invoking instruction ", ixIndex);


### PR DESCRIPTION
This pull request updates the logic for routing transaction execution paths in the `Menu` class to prevent issues with certain authority indices. The main change ensures that only transactions with an `authorityIndex` of 1 or greater can use the sequential `executeInstruction` path, addressing a known on-chain rejection for authority index 0.

**Execution path routing update:**

* Updated the conditional in the `Menu` class (`src/lib/menu.ts`) to only allow the sequential `executeInstruction` path for transactions where `authorityIndex >= 1` and `instructionIndex > 3`, preventing batches with authority index 0 from stalling due to on-chain rejection.