### PR TITLE
fix(members): better scan for multisig members and direct access

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -135,26 +135,44 @@ class API{
         //   8 discriminator + 2 threshold + 2 authorityIndex + 4 transactionIndex
         //   + 4 msChangeIndex + 1 bump + 32 createKey + 1 allowExternalExecute
         //   + 4 vec-length prefix = 58
-        // We scan up to MS_SCAN_POSITIONS positions in parallel; multisigs that
-        // place this wallet beyond that won't be discovered (rare in practice).
+        // memcmp can only match a fixed offset, so we probe one member slot at a
+        // time. A previous fixed 10-slot cap silently hid any membership stored at
+        // slot >= 10. Instead, scan in batches and keep advancing until a full
+        // batch of consecutive slots yields no match. A multisig's `keys` Vec is
+        // dense from slot 0, so once we've covered the baseline and an entire batch
+        // comes back empty, we've passed the largest membership for this wallet.
+        // MIN_SCAN_POSITIONS is probed unconditionally so a wallet that only sits
+        // at a higher slot (e.g. 10) is never missed by an early empty batch.
+        // Server-side memcmp keeps each response small, which matters on mainnet;
+        // operators of unusually large multisigs also have the direct-address entry
+        // path in the menu as a guaranteed fallback.
         const KEYS_OFFSET = 58;
-        const MS_SCAN_POSITIONS = 10;
+        const SCAN_BATCH = 16;
+        const MIN_SCAN_POSITIONS = 64;
         const walletKey = this.wallet.publicKey.toBase58();
-        const queries = Array.from({ length: MS_SCAN_POSITIONS }, (_, i) =>
-            this.program.account.ms.all([
-                { memcmp: { offset: KEYS_OFFSET + i * 32, bytes: walletKey } },
-            ]),
-        );
-        const results = await Promise.all(queries);
         const seen = new Set<string>();
         const msPDAs: PublicKey[] = [];
-        for (const batch of results) {
-            for (const entry of batch) {
-                const key = entry.publicKey.toBase58();
-                if (seen.has(key)) continue;
-                seen.add(key);
-                msPDAs.push(entry.publicKey);
+        let position = 0;
+        let keepScanning = true;
+        while (keepScanning) {
+            const queries = Array.from({ length: SCAN_BATCH }, (_, i) =>
+                this.program.account.ms.all([
+                    { memcmp: { offset: KEYS_OFFSET + (position + i) * 32, bytes: walletKey } },
+                ]),
+            );
+            const results = await Promise.all(queries);
+            let batchHits = 0;
+            for (const batch of results) {
+                for (const entry of batch) {
+                    batchHits++;
+                    const key = entry.publicKey.toBase58();
+                    if (seen.has(key)) continue;
+                    seen.add(key);
+                    msPDAs.push(entry.publicKey);
+                }
             }
+            position += SCAN_BATCH;
+            keepScanning = position < MIN_SCAN_POSITIONS || batchHits > 0;
         }
         return Promise.all(msPDAs.map(k => this.getSquadExtended(k)));
     };

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -154,11 +154,14 @@ class Menu{
             spinner.stop();
             const testList = await loadAuthorities(this.multisigs);
 
+            const byAddressIndex = testList.length;
+            testList.push({ name: "Open a multisig by address", value: byAddressIndex, short: "By address" });
             const dIndex = testList.length;
             testList.push({ name: "<- Go back", value: dIndex, short: "Go back" });
 
             const {action} = await viewMultisigsMenu(testList, dIndex);
             if (action === dIndex) return () => this.top();
+            if (action === byAddressIndex) return () => this.openMultisigByAddress();
             return () => this.multisig(this.multisigs[action]);
         } catch (error) {
             spinner.stop();
@@ -166,6 +169,41 @@ class Menu{
             console.log("Try restarting the cli using a different Solana cluster");
             await continueInq();
             return () => this.top();
+        }
+    };
+
+    // Direct-address fallback for the discovery list. Membership discovery scans
+    // member slots and, while it now grows well past the old 10-slot cap, cannot
+    // prove completeness for arbitrarily large multisigs. This lets an operator
+    // open any multisig by its account address regardless of where their wallet
+    // sits in the members list.
+    openMultisigByAddress = async (): Promise<NextAction> => {
+        const {address} = await inquirer.prompt({
+            default: "",
+            name: 'address',
+            type: 'input',
+            message: 'Enter the multisig account address (base58):',
+        });
+        if (!address || address.trim().length < 1) return () => this.multisigList();
+        let msPubkey: PublicKey;
+        try {
+            msPubkey = new PublicKey(address.trim());
+        } catch (e) {
+            console.log(chalk.red("Invalid public key."));
+            await continueInq();
+            return () => this.multisigList();
+        }
+        const status = new Spinner("Loading multisig...");
+        status.start();
+        try {
+            const ms = await this.api.getSquadExtended(msPubkey);
+            status.stop();
+            return () => this.multisig(ms);
+        } catch (e) {
+            status.stop();
+            console.log(chalk.red("Could not load a multisig at that address. Check the address and cluster."));
+            await continueInq();
+            return () => this.multisigList();
         }
     };
 


### PR DESCRIPTION
This pull request improves the reliability and usability of multisig account discovery and access in the application. The main changes expand the membership scan logic to avoid missing multisigs with members in higher slots, and introduce a direct-address fallback so users can open any multisig by its account address. This ensures operators can always access their multisigs, even for edge cases with large or unusual configurations.

**Improvements to multisig discovery:**

* Replaced the fixed 10-slot membership scan with a dynamic, batched approach that continues scanning in batches of 16 until a full batch yields no results, or until at least 64 positions have been probed. This prevents missing multisigs where the wallet is stored at a higher slot index.

**User interface enhancements:**

* Added a new "Open a multisig by address" option to the multisig list menu, allowing users to directly enter a multisig account address for access, regardless of membership scan results.
* Implemented the `openMultisigByAddress` method, which prompts the user for an address, validates it, attempts to load the multisig, and provides error handling and feedback for invalid or inaccessible addresses.