### PR TITLE
fix(nfts): safesign passes through failed nft authority transfers

### DIFF
--- a/src/lib/nfts.ts
+++ b/src/lib/nfts.ts
@@ -19,6 +19,24 @@ import Squads from "@sqds/sdk";
 import type { Mutable, TxMetaPayload } from "../types.js";
 
 type BatchTransactionCreationError = 'approval' | 'activation' | 'none';
+
+// Builds the metadata update-authority instruction, appending newAuthority as a
+// required signer when safe-sign mode is selected. Both the first-pass and the
+// retry attachment loops must build their instructions through this helper so a
+// mint that only attaches on retry keeps the exact authorization the operator
+// chose — otherwise retried mints would silently lose the safeSign co-sign.
+const buildAuthorityUpdateIx = (newAuthority: PublicKey, currentAuthority: PublicKey, mint: PublicKey, safeSign?: boolean) => {
+    const ix = updateMetadataAuthorityIx(newAuthority, currentAuthority, getMetadataAccount(mint));
+    if (safeSign) {
+        ix.keys.push({
+            pubkey: newAuthority,
+            isSigner: true,
+            isWritable: false
+        });
+    }
+    return ix;
+};
+
 // can fit 250 ixes
 export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: PublicKey, currentAuthority: PublicKey, newAuthority: PublicKey, mints: PublicKey[], connection: Connection, ws: fs.WriteStream, safeSign?: boolean) => {
     // create the transaction to update the authority
@@ -32,6 +50,7 @@ export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: Publi
     await squadsSdk.getTransaction(txState.publicKey);
     const batchLength = mints.length;
     ws.write(`Attaching ${batchLength} instructions for each metadata account\n`);
+    ws.write(`Safe-sign mode: ${safeSign ? "enforced (new authority required as signer)" : "off"}\n`);
     let hasError = false;
     const failures = [];
     while (queue.length > 0) {
@@ -39,18 +58,11 @@ export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: Publi
         if (!mint) {
             break;
         }
-        const ix = updateMetadataAuthorityIx(newAuthority, currentAuthority, getMetadataAccount(mint));
-        if (safeSign) {
-            ix.keys.push({
-                pubkey: newAuthority,
-                isSigner: true,
-                isWritable: false
-            })
-        }
+        const ix = buildAuthorityUpdateIx(newAuthority, currentAuthority, mint, safeSign);
         try {
             const addedIx = await squadsSdk.addInstruction(txState.publicKey, ix);
             if (addedIx) {
-                ws.write(`${mint.toBase58()}\n`);
+                ws.write(`${mint.toBase58()} (safeSign: ${safeSign ? "enforced" : "off"})\n`);
                 attached.push(mint);
             }
             // flash tx state
@@ -70,11 +82,11 @@ export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: Publi
             if (!mint) {
                 break;
             }
-            const ix = updateMetadataAuthorityIx(newAuthority, currentAuthority, getMetadataAccount(mint));
+            const ix = buildAuthorityUpdateIx(newAuthority, currentAuthority, mint, safeSign);
             try {
                 const addedIx = await squadsSdk.addInstruction(txState.publicKey, ix);
                 if (addedIx) {
-                    ws.write(`${mint.toBase58()}\n`);
+                    ws.write(`${mint.toBase58()} (safeSign: ${safeSign ? "enforced" : "off"})\n`);
                     attached.push(mint);
                 }
             }catch (e) {


### PR DESCRIPTION
This pull request refactors and improves the way authority update instructions are constructed and logged in the NFT authority update workflow. The main focus is to ensure that the "safe-sign" mode (which requires the new authority to co-sign) is consistently enforced, especially on retry, and to provide clearer logging for operators.

**Key changes:**

### Instruction Construction

* Added a new helper function `buildAuthorityUpdateIx` to construct the metadata authority update instruction, ensuring that the `safeSign` option is consistently applied both in initial and retry attachment loops. This prevents retried mints from accidentally losing the required co-sign authorization.

### Logging Improvements

* Updated logging in `createAuthorityUpdateTx` to clearly indicate whether "safe-sign" mode is enforced, both in the batch summary and per-mint logs, making operator intent and transaction details more transparent. [[1]](diffhunk://#diff-0bdbfd6700eb357836aafd08d7f4326aec7f57028531e6ca52cef463f248113bR53-R65) [[2]](diffhunk://#diff-0bdbfd6700eb357836aafd08d7f4326aec7f57028531e6ca52cef463f248113bL73-R89)