### PR TITLE
fix(refresh): post-create refreshes stale state

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -239,8 +239,12 @@ class Menu{
             console.log("Transaction created!");
             console.log("Transaction key: " + chalk.blue(tx.publicKey.toBase58()));
             await continueInq();
-            const txs = await this.api.getTransactions(ms);
-            return () => this.transactions(txs, ms);
+            // Re-fetch the multisig: createTransaction bumped transactionIndex on-chain,
+            // and getTransactions derives the list from that index. Using the pre-create
+            // snapshot would omit the proposal just created.
+            const freshMs = await this.api.getSquadExtended(ms.publicKey);
+            const txs = await this.api.getTransactions(freshMs);
+            return () => this.transactions(txs, freshMs);
         }
         if (assemble.indexOf("Enter") == 0) {
             const {authority} = await createTransactionInq();
@@ -274,8 +278,15 @@ class Menu{
                 await this.api.approveTransaction(tx.publicKey);
                 console.log("Transaction created!");
                 await continueInq();
-                const txs = await this.api.getTransactions(ms);
-                return () => this.transactions(txs, ms);
+                // Re-fetch the multisig so the just-created proposal (which bumped
+                // transactionIndex on-chain) is included in the list, then route the
+                // operator straight into its detail screen so they can immediately
+                // review or cancel the live, already-activated-and-approved proposal.
+                const freshMs = await this.api.getSquadExtended(ms.publicKey);
+                const txs = await this.api.getTransactions(freshMs);
+                const createdTx = txs.find(t => t.publicKey.toBase58() === tx.publicKey.toBase58());
+                if (createdTx) return () => this.transaction(createdTx, freshMs, txs);
+                return () => this.transactions(txs, freshMs);
             } catch (e) {
                 console.log("Error", e);
                 status.stop();


### PR DESCRIPTION
This pull request improves the transaction creation and approval flows in the `Menu` class to ensure the UI reflects the latest on-chain state after a new transaction is created or approved. The main changes ensure that the multisig account and transaction list are freshly fetched after these operations, preventing stale data and allowing users to immediately interact with the newly created proposal.

**Improvements to transaction creation and approval flows:**

* After creating a transaction, the multisig account (`ms`) is re-fetched from the API before retrieving the list of transactions, ensuring the new proposal is included in the displayed list. (`src/lib/menu.ts`)
* After approving a transaction, the multisig account is similarly re-fetched, and the user is routed directly to the detail screen of the newly created and approved proposal if it is found, providing a more seamless review or cancellation experience. (`src/lib/menu.ts`)