### PR TITLE
fix(creator): display the creator

### DIFF
--- a/src/lib/inq/transactions.js
+++ b/src/lib/inq/transactions.js
@@ -1,4 +1,5 @@
 import inquirer from "inquirer";
+import { shortenTextEnd } from "../utils.js";
 
 export default (txs, userKey) => {
     const visible = txs.filter((tx) => {
@@ -11,10 +12,14 @@ export default (txs, userKey) => {
     if (visible.length < 1) {
         console.log("No transactions found");
     }
-    const choices = visible.map((tx) => ({
-        name: `${tx.publicKey.toBase58()} (${Object.keys(tx.status)[0]})`,
-        value: tx.publicKey.toBase58(),
-    }));
+    const choices = visible.map((tx) => {
+        const creator = tx.creator.toBase58();
+        const isSelf = creator === userKey.toBase58();
+        return {
+            name: `${tx.publicKey.toBase58()} (${Object.keys(tx.status)[0]}) — by ${shortenTextEnd(creator, 8)}${isSelf ? " (you)" : ""}`,
+            value: tx.publicKey.toBase58(),
+        };
+    });
     choices.push({ name: "<- Go back", value: null });
 
     return inquirer.prompt([{

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -319,9 +319,11 @@ class Menu{
         const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         const authority = await this.api.getAuthority(ms.publicKey, tx.authorityIndex);
+        const creatorIsSelf = tx.creator.toBase58() === this.wallet.publicKey.toBase58();
         const txData = [
             {
                 status: Object.keys(tx.status)[0],
+                creator: tx.creator.toBase58() + (creatorIsSelf ? " (you)" : ""),
                 authority: authority.toBase58(),
                 approved: tx.approved.length,
                 rejected: tx.rejected.length,


### PR DESCRIPTION
This pull request enhances the user experience by making it easier to identify transaction creators, especially when the creator is the current user. The main updates add clear labeling and improved formatting to transaction listings and details.

**Improvements to transaction display:**

* Transaction selection now shows the creator's address (shortened) and marks if the creator is the current user, using the `shortenTextEnd` utility for formatting. (`src/lib/inq/transactions.js`) [[1]](diffhunk://#diff-5cb7961bc834b854861db035acdd817061425abdc9a9089e2104ae7d6c9a89a4R2) [[2]](diffhunk://#diff-5cb7961bc834b854861db035acdd817061425abdc9a9089e2104ae7d6c9a89a4L14-R22)
* Transaction details in the menu now display the creator's address and append "(you)" if the creator matches the current user's wallet. (`src/lib/menu.ts`)