### PR TITLE
fix(settings): atomic approval in submitBuilderTx (prevent auth-0 PDA redirect)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -70,7 +70,10 @@ class API{
         try {
             const sig = await this.connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
             if (confirm) {
-                await this.connection.confirmTransaction(sig, "confirmed");
+                const response = await this.connection.confirmTransaction(sig, "confirmed");
+                if (response.value?.err) {
+                    throw new Error(`Transaction failed on-chain: ${JSON.stringify(response.value.err)}`);
+                }
             }
             return sig;
         } catch (e) {
@@ -82,7 +85,9 @@ class API{
     };
 
     // Builder-driven multisig config changes (auth index 0): add/remove member, change threshold.
-    // Sends create+add+activate (+ optional topup) in one Solana tx, then casts the caller's approval.
+    // Sends create+add+activate (+ optional topup) plus the caller's approval in one atomic
+    // Solana tx, so the approval can never land on a different account at the deterministic
+    // tx PDA if the create/activate leg fails on-chain.
     private submitBuilderTx = async (
         msPDA: PublicKey,
         mutate: (b: SquadsTxBuilder) => Promise<SquadsTxBuilder>,
@@ -91,14 +96,14 @@ class API{
         const builder = await this.squads.getTransactionBuilder(msPDA, 0);
         const [txInstructions, txPDA] = await (await mutate(builder)).getInstructions();
         const activateIx = await this.squads.buildActivateTransaction(msPDA, txPDA);
+        const approveIx = await this.squads.buildApproveTransaction(msPDA, txPDA);
         const ixes: anchor.web3.TransactionInstruction[] = [];
         if (opts.includeTopUp) {
             const topup = await this.squads.checkGetTopUpInstruction(msPDA);
             if (topup) ixes.push(topup);
         }
-        ixes.push(...txInstructions, activateIx);
+        ixes.push(...txInstructions, activateIx, approveIx);
         await this.sendAndConfirm(ixes);
-        await this.squads.approveTransaction(txPDA);
         return this.squads.getTransaction(txPDA);
     };
 


### PR DESCRIPTION
## Summary

`submitBuilderTx` in `src/lib/api.ts` builds an authority-0 settings change (add/remove member, change threshold) and previously sent `create + addInstruction + activate` in one transaction, then cast the operator's approval in a **separate** RPC call via `approveTransaction(txPDA)`. The `txPDA` is derived deterministically from `transactionIndex + 1`.

Because `sendAndConfirm` ran with `skipPreflight: true` and called `confirmTransaction(sig, "confirmed")` without checking `value.err`, a create/activate leg that failed on-chain was still reported as success. The follow-up approve leg would then approve whatever transaction account currently occupies that deterministic PDA — e.g. a racing attacker-controlled authority-0 transaction — redirecting the operator's approval to a malicious settings change (such as threshold → 1).

## Fix

1. **Atomic approval:** Build the approve instruction via `this.squads.buildApproveTransaction(msPDA, txPDA)` and bundle it into the **same** transaction as create/add/activate (matching the sibling `submitAsMultisigTx`). The separate `approveTransaction` RPC call is removed. If create/activate fails on-chain, the entire transaction — including the approval — fails atomically, so the approval can never land on a different account at that PDA.
2. **Harden `sendAndConfirm`:** Capture the `confirmTransaction` response and throw when `response.value?.err` is truthy, instead of treating a failed-but-confirmed transaction as success. The existing insufficient-funds catch/return behavior is preserved.

Verified with `npx tsc --noEmit`: no new errors (only the unrelated pre-existing line-40 `payer` error, fixed by another open PR).

Apex Report — squads-cli SQUA1-13 (Urgent)

Fixes MUL-791
https://linear.app/sqds/issue/MUL-791

🤖 Generated with [Claude Code](https://claude.com/claude-code)