### PR TITLE
fix(assets): show token label provenance in vault inventory

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -32,6 +32,7 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
         symbol: 'SOL',
         decimals: 9,
         name: "Solana",
+        provenance: 'registry',
     }];
 
     // Exclude wrapped-SOL token accounts (the native SOL row already covers it).
@@ -76,6 +77,7 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
                         symbol: md.symbol,
                         decimals,
                         name: md.name,
+                        provenance: 'metadata',
                     });
                     return;
                 } catch {
@@ -90,6 +92,7 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
                     amount, source, mint: listEntry.address,
                     symbol: listEntry.symbol, decimals,
                     name: listEntry.name,
+                    provenance: 'registry',
                 });
                 return;
             }
@@ -99,9 +102,18 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
                 amount, source, mint: mintStr,
                 symbol: shortenTextEnd(mintStr, 4),
                 decimals, name: "UNKNOWN",
+                provenance: 'unknown',
             });
         });
     }
+
+    // Human-readable trust signal for the label source. Metadata labels are
+    // attacker-controllable, so they are explicitly flagged as unverified.
+    const provenanceLabel: Record<TokenAsset['provenance'], string> = {
+        metadata: 'on-chain metadata (unverified)',
+        registry: 'token registry',
+        unknown: 'unknown',
+    };
 
     const displayTokens = usableTokens.map(a => ({
         Amount: a.amount,
@@ -109,6 +121,7 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
         Mint: a.mint,
         Symbol: a.symbol,
         Name: a.name,
+        Source: provenanceLabel[a.provenance],
     }));
     return { usableTokens, displayTokens };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,10 @@ export interface TokenAsset {
     symbol: string;
     decimals: number;
     name: string;
+    // Where the symbol/name label came from. `metadata` is attacker-controllable
+    // (on-chain Metaplex metadata of any mint), so the label is unverified; the
+    // mint address remains the authoritative identifier.
+    provenance: 'metadata' | 'registry' | 'unknown';
 }
 
 export interface AssetBundle {
@@ -34,6 +38,7 @@ export interface AssetBundle {
         Mint: string;
         Symbol: string;
         Name: string;
+        Source: string;
     }>;
 }
 


### PR DESCRIPTION
## Summary

The vault inventory table (`getAssets` in `src/lib/assets.ts`) labelled SPL token rows using `name`/`symbol` pulled straight from each mint's on-chain Metaplex metadata account — which is attacker-controllable for any mint they create — or from the public SPL token registry, with **no indication of where the label came from**. A counterfeit token could therefore display spoofed blue-chip branding (e.g. name "USD Coin" / symbol "USDC") indistinguishable from the genuine asset.

## Fix

- Added a `provenance` tag (`'metadata' | 'registry' | 'unknown'`) to the `TokenAsset` type and set it on every row in `getAssets`:
  - native SOL → `registry` (well-known asset)
  - on-chain Metaplex metadata → `metadata`
  - SPL token registry fallback → `registry`
  - unknown/truncated mint → `unknown`
- Surfaced it in the displayed table as a new **Source** column with human-readable labels: `on-chain metadata (unverified)`, `token registry`, `unknown`. Existing columns (Amount, Account, Mint, Symbol, Name) are unchanged.
- The mint address remains the authoritative identifier; this is labelling, not blocking — no asset is hidden.

## Notes

- This overlaps PR #31 (WSOL handling) in `src/lib/assets.ts`, so depending on merge order a trivial rebase may be needed. The WSOL/NFT-exclusion behaviour on this branch is left untouched.
- `npx tsc --noEmit` is clean apart from the pre-existing `src/lib/api.ts(40,59)` `payer` error.

Apex Report — squads-cli SQUA1-3 (Low)

Fixes MUL-799
https://linear.app/sqds/issue/MUL-799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
