### PR TITLE
feat(vault/nft): selectable authority index for inventory and NFT flows

### DIFF
--- a/src/lib/inq/authorityIndex.js
+++ b/src/lib/inq/authorityIndex.js
@@ -1,0 +1,18 @@
+import inquirer from "inquirer";
+
+export default () => {
+    const questions = [
+        {
+            default: 1,
+            name: 'authorityIndex',
+            type: 'number',
+            message: 'Enter the authority index to use (default 1):',
+            validate: function( value ) {
+                if (Number.isInteger(value) && value >= 1) {
+                    return true;
+                }
+                return 'Authority index must be a whole number >= 1';
+            },
+        }];
+    return inquirer.prompt(questions);
+};

--- a/src/lib/inq/index.js
+++ b/src/lib/inq/index.js
@@ -17,6 +17,7 @@ import continueInq from "./continue.js";
 import addInstructionInq from "./addInstruction.js";
 import withdrawInq from "./withdraw.js";
 import createATAInq from "./createATA.js";
+import authorityIndexInq from "./authorityIndex.js";
 import {
     nftMainInq,
     nftUpdateAuthorityInq,
@@ -49,6 +50,7 @@ export {
     createATAInq,
     addTransactionInq,
     addInstructionInq,
+    authorityIndexInq,
     promptProgramId,
     transactionPrompt,
     basicConfirm,

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -24,6 +24,7 @@ import {
     createTransactionInq,
     addInstructionInq,
     addTransactionInq,
+    authorityIndexInq,
     promptProgramId,
     transactionPrompt,
     basicConfirm,
@@ -179,12 +180,13 @@ class Menu{
         console.log(" ");
         const {action} = await multisigMainMenu(ms);
         if (action === MULTISIG.VAULT) {
+            const {authorityIndex} = await authorityIndexInq();
             const status = new Spinner("Loading vault");
             status.start();
-            const vaultPDA = await this.api.getVault(ms.publicKey);
+            const vaultPDA = await this.api.getAuthority(ms.publicKey, authorityIndex);
             const vaultAssets = await this.api.getVaultAssets(vaultPDA);
             status.stop();
-            return () => this.vault(ms, vaultPDA, vaultAssets);
+            return () => this.vault(ms, vaultPDA, vaultAssets, authorityIndex);
         }
         else if (action === MULTISIG.SETTINGS) {
             return () => this.settings(ms);
@@ -468,9 +470,10 @@ class Menu{
         return () => this.transaction(tx, ms, txs);
     };
 
-    vault = async (ms: MultisigAccount, vaultPDA: PublicKey, vd: AssetBundle): Promise<NextAction> => {
+    vault = async (ms: MultisigAccount, vaultPDA: PublicKey, vd: AssetBundle, authorityIndex: number = 1): Promise<NextAction> => {
         this.header();
-        console.log("Vault Address: " + chalk.blue(vaultPDA.toBase58()));
+        const indexLabel = authorityIndex === 1 ? `${authorityIndex} (default)` : `${authorityIndex}`;
+        console.log(`Vault Address (authority index ${indexLabel}): ` + chalk.blue(vaultPDA.toBase58()));
         console.table(vd.displayTokens);
         await continueInq();
         return () => this.multisig(ms);
@@ -724,14 +727,20 @@ class Menu{
         return () => this.multisig(ms);
     };
 
-    nfts = async (ms: MultisigAccount): Promise<NextAction> => {
+    nfts = async (ms: MultisigAccount, authorityIndex?: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
+        // Prompt for the authority index once on entry into the NFT flows, then
+        // thread the selected index/PDA through every sub-flow. When re-entered
+        // (e.g. returning from a sub-flow) the previously selected index is kept.
+        const index = authorityIndex ?? (await authorityIndexInq()).authorityIndex;
+        const vault = await this.api.getAuthority(ms.publicKey, index);
         this.header(vault);
+        const indexLabel = index === 1 ? `${index} (default)` : `${index}`;
+        console.log(`Using authority index ${indexLabel} - vault: ` + chalk.blue(vault.toBase58()));
         const {action} = await nftMainInq();
-        if (action === 0) return () => this.nftAuthorityChange(ms);
-        if (action === 1) return () => this.nftValidateMetaAuthorities(ms);
-        if (action === 2) return () => this.nftBatchTransfer(ms);
+        if (action === 0) return () => this.nftAuthorityChange(ms, vault, index);
+        if (action === 1) return () => this.nftValidateMetaAuthorities(ms, vault, index);
+        if (action === 2) return () => this.nftBatchTransfer(ms, vault, index);
         return () => this.multisig(ms);
     };
 
@@ -806,9 +815,8 @@ class Menu{
         }
     };
 
-    nftAuthorityChange = async (ms: MultisigAccount): Promise<NextAction> => {
+    nftAuthorityChange = async (ms: MultisigAccount, vault: PublicKey, authorityIndex: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         const {type, publicKey, mintList} = await nftUpdateAuthorityInq();
         let newAuthority = vault;
@@ -831,18 +839,17 @@ class Menu{
 
         if (error) {
             await continueInq();
-            return () => this.nfts(ms);
+            return () => this.nfts(ms, authorityIndex);
         }
-        if (type === 0) return () => this.nftAuthorityChangeIncoming(ms, allMints, newAuthority);
-        if (type === 1) return () => this.nftAuthorityChangeOutgoing(ms, allMints, newAuthority);
+        if (type === 0) return () => this.nftAuthorityChangeIncoming(ms, allMints, newAuthority, vault, authorityIndex);
+        if (type === 1) return () => this.nftAuthorityChangeOutgoing(ms, allMints, newAuthority, vault, authorityIndex);
         await continueInq();
-        return () => this.nfts(ms);
+        return () => this.nfts(ms, authorityIndex);
     };
 
     // this can simply be transferred to the vault directly with metaplex program
-    nftAuthorityChangeIncoming = async (ms: MultisigAccount, mintList: PublicKey[], newAuthority: PublicKey): Promise<NextAction> => {
+    nftAuthorityChangeIncoming = async (ms: MultisigAccount, mintList: PublicKey[], newAuthority: PublicKey, vault: PublicKey, authorityIndex: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         const {validate} = await nftValidateMetasInq();
         let error = false;
@@ -929,13 +936,12 @@ class Menu{
 
             await continueInq();
         }
-        return () => this.nfts(ms);
+        return () => this.nfts(ms, authorityIndex);
     };
 
     // to move the authority out, transaction will need to be created
-    nftAuthorityChangeOutgoing = async (ms: MultisigAccount, mintList: PublicKey[], newAuthority: PublicKey): Promise<NextAction> => {
+    nftAuthorityChangeOutgoing = async (ms: MultisigAccount, mintList: PublicKey[], newAuthority: PublicKey, vault: PublicKey, authorityIndex: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         let error = false;
         const {ownerValidate} = await nftValidateOwnerInq();
@@ -994,7 +1000,7 @@ class Menu{
             try {
                 transferOutWriteStream.write("Initiating bulk outgoing authority change transactions\n");
                 for(const batch of buckets){
-                    const metasAdded = await createAuthorityUpdateTx(this.api.squads, ms.publicKey, vault, newAuthority, batch, this.api.connection, transferOutWriteStream, safeSign);
+                    const metasAdded = await createAuthorityUpdateTx(this.api.squads, ms.publicKey, vault, newAuthority, batch, this.api.connection, transferOutWriteStream, safeSign, authorityIndex);
                     successfullyStagedMetas.push(...metasAdded.attached);
 
                     // if we haven't had an activation error, activate it
@@ -1026,12 +1032,11 @@ class Menu{
             console.log(`Output logs written to: ${logFilename}`);
             await continueInq();
         }
-        return () => this.nfts(ms);
+        return () => this.nfts(ms, authorityIndex);
     };
 
-    nftValidateMetaAuthorities = async (ms: MultisigAccount): Promise<NextAction> => {
+    nftValidateMetaAuthorities = async (ms: MultisigAccount, vault: PublicKey, authorityIndex: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         let error = false;
         console.log("This process will check that all the provided mints specified have the proper matching metadata account update authority, and also possess valid metadata accounts.");
@@ -1072,12 +1077,11 @@ class Menu{
                 await continueInq();
             }
         }
-        return () => this.nfts(ms);
+        return () => this.nfts(ms, authorityIndex);
     };
 
-    nftBatchTransfer = async (ms: MultisigAccount): Promise<NextAction> => {
+    nftBatchTransfer = async (ms: MultisigAccount, vault: PublicKey, authorityIndex: number): Promise<NextAction> => {
         clear();
-        const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
         const {mintList} = await nftMintListInq();
         if (mintList && mintList.length > 0) {
@@ -1128,7 +1132,7 @@ class Menu{
                 // setup log file
                 const fullResults = [];
                 for(const batch of buckets){
-                    const metasAdded = await createWithdrawNftTx(this.api.squads, ms.publicKey, vault, new PublicKey(destination), batch, this.api.connection);
+                    const metasAdded = await createWithdrawNftTx(this.api.squads, ms.publicKey, vault, new PublicKey(destination), batch, this.api.connection, authorityIndex);
                     successfullyStagedMetas.push(...metasAdded.attached);
 
                     // if we haven't had an activation error, activate it
@@ -1154,7 +1158,7 @@ class Menu{
         }
         // this goes back to main nft menu
         await continueInq();
-        return () => this.nfts(ms);
+        return () => this.nfts(ms, authorityIndex);
     };
 }
 

--- a/src/lib/nfts.ts
+++ b/src/lib/nfts.ts
@@ -20,14 +20,14 @@ import type { Mutable, TxMetaPayload } from "../types.js";
 
 type BatchTransactionCreationError = 'approval' | 'activation' | 'none';
 // can fit 250 ixes
-export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: PublicKey, currentAuthority: PublicKey, newAuthority: PublicKey, mints: PublicKey[], connection: Connection, ws: fs.WriteStream, safeSign?: boolean) => {
+export const createAuthorityUpdateTx = async (squadsSdk: Squads, multisig: PublicKey, currentAuthority: PublicKey, newAuthority: PublicKey, mints: PublicKey[], connection: Connection, ws: fs.WriteStream, safeSign?: boolean, authorityIndex: number = 1) => {
     // create the transaction to update the authority
     // attach the update authority ix to the transaction (up to 250)
     const attached = [];
     const attachFails = [];
     let txError: BatchTransactionCreationError = 'none';
     const queue = mints;
-    let txState = await squadsSdk.createTransaction(multisig, 1);
+    let txState = await squadsSdk.createTransaction(multisig, authorityIndex);
     ws.write(`Created Transaction at PDA: ${txState.publicKey.toBase58()}\n`);
     await squadsSdk.getTransaction(txState.publicKey);
     const batchLength = mints.length;
@@ -328,14 +328,14 @@ export const checkIfMintsAreValidAndOwnedByVault = async (connection: Connection
     return {success,failures}
 }
 
-export const createWithdrawNftTx = async (squadsSdk: Squads, multisig: PublicKey, vault: PublicKey, destination: PublicKey, mints: PublicKey[], connection: Connection) => {
+export const createWithdrawNftTx = async (squadsSdk: Squads, multisig: PublicKey, vault: PublicKey, destination: PublicKey, mints: PublicKey[], connection: Connection, authorityIndex: number = 1) => {
     // create the transaction to update the authority
     // attach the update authority ix to the transaction (up to 250)
     const attached = [];
     const attachFails = [];
     let txError: BatchTransactionCreationError = 'none';
     const queue = mints;
-    let txState = await squadsSdk.createTransaction(multisig, 1);
+    let txState = await squadsSdk.createTransaction(multisig, authorityIndex);
     const batchLength = mints.length;
     let hasError = false;
     const failures = [];


### PR DESCRIPTION
## Summary

The vault inventory screen and the NFT helper flows (`nfts`, `nftAuthorityChange`, `nftAuthorityChangeIncoming`, `nftAuthorityChangeOutgoing`, `nftBatchTransfer`) hardcoded authority index 1 via `getVault = (msPDA) => this.getAuthority(msPDA, 1)`. As a result, assets and NFT control held under any other valid squad authority PDA (index 2, 3, ...) were invisible to operators — a custody-scope blind spot (not an unauthorized-transfer issue).

## Fix

- Added a small reusable prompt `src/lib/inq/authorityIndex.js` (inquirer `number`, default 1, validates whole number >= 1) and exported it from `src/lib/inq/index.js`.
- **Vault inventory** (`multisig()` → `MULTISIG.VAULT`): now prompts for an authority index, derives `getAuthority(ms, index)`, reads assets from the selected PDA, and labels the screen `Vault Address (authority index N): <pda>` (noting `(default)` for index 1).
- **NFT flows**: `nfts()` prompts for the authority index once on entry, derives the selected authority PDA, and threads both the PDA and index through all sub-flows so the default incoming `newAuthority`, ownership checks (`checkIfMintsAreValidAndOwnedByVault`, `checkAllMetasAuthority`), and staged multisig transactions all use the selected authority.
- `createAuthorityUpdateTx` and `createWithdrawNftTx` in `src/lib/nfts.ts` gained an `authorityIndex` parameter (default 1) used in their `createTransaction(multisig, authorityIndex)` calls.
- `getVault`'s default-1 behavior and all other callers (settings, transactions, program/validator flows) are unchanged. Accepting the default index reproduces prior behavior exactly.

`npx tsc --noEmit` reports only the pre-existing `src/lib/api.ts(40,59)` error; no new errors.

Fixes MUL-797
https://linear.app/sqds/issue/MUL-797
Apex Report — squads-cli SQUA1-25 (Low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)