### PR TITLE
fix(settings): reject semantic no-op member/threshold proposals

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -499,6 +499,11 @@ class Menu{
         const {yes} = await basicConfirm(`Create transaction to add ${memberKey}?`, false);
         if (!yes) return () => this.addKey(ms);
         const newKey = new PublicKey(memberKey);
+        if (ms.keys.some((k) => k.equals(newKey))) {
+            console.log(chalk.red(`${newKey.toBase58()} is already a member of this multisig — this would be a no-op that can invalidate other active proposals.`));
+            await continueInq();
+            return () => this.settings(ms);
+        }
         const status = new Spinner("Creating New Member Transaction...");
         status.start();
         try {
@@ -557,6 +562,11 @@ class Menu{
         });
         if (threshold === "") return () => this.settings(ms);
         const thresholdInt = Number(threshold);
+        if (thresholdInt === ms.threshold) {
+            console.log(chalk.red(`The threshold is already ${ms.threshold} — this would be a no-op that can invalidate other active proposals.`));
+            await continueInq();
+            return () => this.settings(ms);
+        }
         const {yes} = await basicConfirm(`Create transaction to change threshold to ${thresholdInt}?`, false);
         if (!yes) return () => this.settings(ms);
         const status = new Spinner("Creating Change Threshold Transaction...");


### PR DESCRIPTION
## Summary

The CLI allowed staging semantic no-op settings proposals — `addKey(existing_member)` and `changeThreshold(current_threshold)`. These change nothing on-chain, but on execution they still advance the multisig's `ms_change_index`, which **deprecates every older active proposal** (they then fail with `DeprecatedTransaction`).

This is exploitable: a member can quietly invalidate a defensive in-flight proposal (e.g. a `removeKey` targeting that member) by executing a harmless-looking no-op.

### Fix
`src/lib/menu.ts` now refuses to stage these no-ops before the transaction is created:
- `addKey`: rejects when the new key is already a member (`ms.keys.some((k) => k.equals(newKey))`).
- `changeThreshold`: rejects when the requested threshold equals the current threshold (`thresholdInt === ms.threshold`).

Both print a clear warning, wait for acknowledgement, and return to the settings menu.

⚠️ **Stacked on PR #44 (MUL-796)** — merge that first, then this PR's base should be retargeted to `main`. (This PR builds on 796's `changeThreshold` integer normalization.)

Fixes MUL-795
https://linear.app/sqds/issue/MUL-795

Apex Report — squads-cli SQUA1-15 (High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)