### PR TITLE
fix(program):  verified on-chain state rather than a precomputed address

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import Squads, { getTxPDA, getAuthorityPDA } from "@sqds/sdk";
+import Squads, { getTxPDA, getIxPDA, getAuthorityPDA } from "@sqds/sdk";
 import * as anchor from "@coral-xyz/anchor";
 import BN from "bn.js";
 import chalk from "chalk";
@@ -10,7 +10,7 @@ import { ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import {Connection, LAMPORTS_PER_SOL, PublicKey, VoteProgram} from "@solana/web3.js";
 import type CliConnection from "./connection.js";
-import type { AnchorWallet, MultisigAccount, SquadsTxBuilder, TransactionAccount } from "../types.js";
+import type { AnchorWallet, InstructionAccount, MultisigAccount, SquadsTxBuilder, TransactionAccount } from "../types.js";
 
 // Below this balance, warn the user that the fee-paying wallet may not have
 // enough SOL to cover the next tx's fees + rent. Heuristic, not a hard floor.
@@ -70,7 +70,17 @@ class API{
         try {
             const sig = await this.connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
             if (confirm) {
-                await this.connection.confirmTransaction(sig, "confirmed");
+                // confirmTransaction resolves (does not throw) for a tx that landed
+                // on chain but failed execution — the failure surfaces in value.err.
+                // Because we skip preflight, that errored-but-confirmed case is the
+                // only signal we get, so treat any non-null err as a hard failure.
+                const { value } = await this.connection.confirmTransaction(
+                    { signature: sig, blockhash, lastValidBlockHeight },
+                    "confirmed",
+                );
+                if (value.err) {
+                    throw new Error(`Transaction ${sig} failed on chain: ${JSON.stringify(value.err)}`);
+                }
             }
             return sig;
         } catch (e) {
@@ -112,7 +122,52 @@ class API{
         const activateIx = await this.squads.buildActivateTransaction(msPDA, txPDA);
         const approveIx = await this.squads.buildApproveTransaction(msPDA, txPDA);
         await this.sendAndConfirm([createTxIx, addIx, activateIx, approveIx]);
+        // The txPDA above is precomputed from transactionIndex+1 and is therefore
+        // deterministic/raceable: a competing member can occupy the same index, so
+        // a confirmed signature alone is not proof that WE staged the tx we showed
+        // the operator. Re-fetch the account and verify its contents before
+        // returning the address as a successfully created transaction.
+        await this.verifyStagedTx(msPDA, txPDA, innerIx, 1);
         return txPDA;
+    };
+
+    // Confirms the on-chain transaction at txPDA is the one we just staged:
+    // owned by this multisig, authored by us, on the expected authority index,
+    // and carrying exactly the instruction we attached. Throws on any mismatch
+    // so callers never report an aliased/attacker-controlled PDA as success.
+    private verifyStagedTx = async (
+        msPDA: PublicKey,
+        txPDA: PublicKey,
+        expectedIx: anchor.web3.TransactionInstruction,
+        authorityIndex: number,
+    ): Promise<void> => {
+        let tx: TransactionAccount;
+        try {
+            tx = await this.squads.getTransaction(txPDA);
+        } catch (_e) {
+            throw new Error("Transaction was not created on chain (account not found).");
+        }
+        if (!tx.ms.equals(msPDA)) throw new Error("Created transaction belongs to a different multisig.");
+        if (!tx.creator.equals(this.wallet.publicKey)) throw new Error("Created transaction was authored by another member.");
+        if (tx.authorityIndex !== authorityIndex) throw new Error(`Created transaction has unexpected authority index ${tx.authorityIndex}.`);
+
+        const [ixPDA] = getIxPDA(txPDA, new BN(1), this.programId);
+        let ix: InstructionAccount;
+        try {
+            ix = await this.squads.getInstruction(ixPDA);
+        } catch (_e) {
+            throw new Error("Expected instruction was not attached to the created transaction.");
+        }
+        if (!ix.programId.equals(expectedIx.programId)) throw new Error("Attached instruction targets an unexpected program.");
+        if (!Buffer.from(ix.data).equals(expectedIx.data)) throw new Error("Attached instruction data does not match.");
+        if (ix.keys.length !== expectedIx.keys.length) throw new Error("Attached instruction account list does not match.");
+        for (let i = 0; i < expectedIx.keys.length; i++) {
+            const got = ix.keys[i];
+            const want = expectedIx.keys[i];
+            if (!got.pubkey.equals(want.pubkey) || got.isSigner !== want.isSigner || got.isWritable !== want.isWritable) {
+                throw new Error("Attached instruction accounts do not match.");
+            }
+        }
     };
 
     getSquadExtended = async (ms: PublicKey) => {


### PR DESCRIPTION
This pull request enhances the robustness and safety of transaction creation in the `API` class by ensuring that newly staged transactions are thoroughly verified on-chain before being reported as successful. It also improves error handling for transaction confirmation and introduces several type and import adjustments for better code clarity and correctness.

**Transaction verification and error handling improvements:**

* Added a `verifyStagedTx` private method to the `API` class to confirm that a newly created transaction matches the expected multisig, creator, authority index, and attached instruction. This prevents race conditions and ensures that the transaction staged is the one intended, not an aliased or attacker-controlled PDA. (`src/lib/api.ts`)
* Modified the transaction confirmation logic in `sendAndConfirm` to throw an error if the transaction lands on-chain but fails execution, ensuring that only successful transactions are reported as confirmed. (`src/lib/api.ts`)

**Type and import updates:**

* Added `getIxPDA` to the imports from `@sqds/sdk` and included the `InstructionAccount` type in the imports from `../types.js`, supporting the new verification logic. (`src/lib/api.ts`) [[1]](diffhunk://#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0dL1-R1) [[2]](diffhunk://#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0dL13-R13)