### PR TITLE
fix(nfts): discerment via metaplex

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -2,14 +2,27 @@ import {Connection, LAMPORTS_PER_SOL, PublicKey} from "@solana/web3.js";
 import {TOKEN_PROGRAM_ID} from "@solana/spl-token";
 import {TokenListProvider} from "@solana/spl-token-registry";
 import {lamports, toMetadata, toMetadataAccount, UnparsedMaybeAccount} from "@metaplex-foundation/js";
+import {TokenStandard} from "@metaplex-foundation/mpl-token-metadata";
 import {getMultipleAccountsBatch, shortenTextEnd} from "./utils.js";
 import {getEditionAccount, getMetadataAccount} from "./nfts.js";
 import type {AssetBundle, TokenAsset} from "../types.js";
 
 const WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112";
 
+// Token standards that represent non-fungible assets. Anything else (Fungible,
+// FungibleAsset, or metadata without a token standard) is treated as fungible.
+const NON_FUNGIBLE_STANDARDS = new Set<TokenStandard>([
+    TokenStandard.NonFungible,
+    TokenStandard.NonFungibleEdition,
+    TokenStandard.ProgrammableNonFungible,
+    TokenStandard.ProgrammableNonFungibleEdition,
+]);
+
 // Returns SOL + SPL token holdings for `userKey`. NFTs (detected by Edition
-// account existence or decimals=0) are excluded from the displayed list.
+// account existence, or by decoded non-fungible token-standard metadata) are
+// excluded from the displayed list. Decimals are NOT used as an NFT signal:
+// ordinary zero-decimal fungible/semi-fungible mints are real custody and must
+// stay visible.
 //
 // Previously this fetched metadata + edition + off-chain JSON per token
 // sequentially (3N round-trips). Now it derives all PDAs up front and batches
@@ -56,9 +69,9 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
             const amount: number = acc.account.data.parsed.info.tokenAmount.uiAmount;
             const source = acc.pubkey.toBase58();
 
-            // NFT heuristic: has an Edition account OR decimals === 0.
-            const isNFT = editionAccounts[i] !== null || decimals === 0;
-            if (isNFT) return;
+            // An Edition account is canonical proof of a non-fungible mint
+            // (master editions for 1/1s, edition prints, and pNFTs all have one).
+            if (editionAccounts[i] !== null) return;
 
             // Prefer on-chain metadata for symbol/name when available.
             const metaEntry = metadataAccounts[i];
@@ -71,6 +84,11 @@ export const getAssets = async (connection: Connection, userKey: PublicKey): Pro
                         lamports: lamports(metaEntry.account.lamports),
                     } as UnparsedMaybeAccount;
                     const md = toMetadata(toMetadataAccount(unparsed));
+                    // Drop mints positively identified as non-fungible by their
+                    // token standard, even without an edition account.
+                    if (md.tokenStandard !== null && NON_FUNGIBLE_STANDARDS.has(md.tokenStandard)) {
+                        return;
+                    }
                     usableTokens.push({
                         amount, source, mint: mintStr,
                         symbol: md.symbol,


### PR DESCRIPTION
This pull request refines the logic for identifying and excluding non-fungible tokens (NFTs) from the list of displayed assets in the `getAssets` function. The main improvement is to use the on-chain token standard metadata, rather than relying on the token's decimals, to more accurately distinguish non-fungible assets from fungible ones. This ensures that only true NFTs are excluded, while zero-decimal fungible tokens remain visible.

**Improvements to NFT detection and asset filtering:**

* Introduced a `NON_FUNGIBLE_STANDARDS` set to clearly define which token standards are considered non-fungible, using the `TokenStandard` enum from the Metaplex token metadata library.
* Updated the NFT detection logic to exclude tokens with an Edition account (canonical proof of non-fungibility) and to no longer use `decimals === 0` as a heuristic, allowing zero-decimal fungible tokens to be shown.
* Added an additional check to exclude tokens whose `tokenStandard` metadata field matches any value in `NON_FUNGIBLE_STANDARDS`, even if they lack an Edition account.