### PR TITLE
fix(confirm): better logic for failed tx

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -315,6 +315,27 @@ class Menu{
         }
     };
 
+    // Builds, signs, sends, and confirms a single executeInstruction tx, throwing
+    // if the transaction failed on chain. confirmTransaction resolves (rather than
+    // throwing) when the failure arrives over the websocket subscription — the
+    // SignatureResult, including a non-null err, comes back on the resolve path —
+    // so the only reliable failure signal is inspecting result.value.err here.
+    private executeOneInstruction = async (
+        txPDA: PublicKey,
+        ixPDA: PublicKey,
+        computeBudgetIx: anchor.web3.TransactionInstruction,
+    ): Promise<void> => {
+        const ix = await this.api.executeInstructionBuilder(txPDA, ixPDA);
+        const {blockhash, lastValidBlockHeight} = await this.api.connection.getLatestBlockhash();
+        const executeIxTx = new Transaction({lastValidBlockHeight, blockhash, feePayer: this.wallet.publicKey});
+        executeIxTx.add(computeBudgetIx, ix);
+        const signed = await this.wallet.signTransaction(executeIxTx);
+        const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
+        console.log(`ix signature: ${txid}`);
+        const result = await this.api.connection.confirmTransaction({signature: txid, blockhash, lastValidBlockHeight}, "confirmed");
+        if (result.value.err) throw new Error(`Instruction failed on chain: ${JSON.stringify(result.value.err)}`);
+    };
+
     transaction = async (tx: TransactionAccount, ms: MultisigAccount, txs: TransactionAccount[]): Promise<NextAction> => {
         const vault = await this.api.getVault(ms.publicKey);
         this.header(vault);
@@ -385,28 +406,18 @@ class Menu{
                         const [ixPDA] = getIxPDA(tx.publicKey, new anchor.BN(ixIndex), this.api.programId);
                         console.log("invoking instruction ", ixIndex);
                         try {
-                            const ix = await this.api.executeInstructionBuilder(tx.publicKey, ixPDA);
-                            const {blockhash, lastValidBlockHeight} = await this.api.connection.getLatestBlockhash();
-                            const executeIxTx = new Transaction({lastValidBlockHeight, blockhash, feePayer: this.wallet.publicKey});
-                            executeIxTx.add(additionalComputeBudgetInstruction, ix);
-                            const signed = await this.wallet.signTransaction(executeIxTx);
-                            const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
-                            console.log(`ix ${ixIndex} signature: ${txid}`);
-                            await this.api.connection.confirmTransaction(txid, "confirmed");
-                            await this.api.squads.getTransaction(tx.publicKey);
+                            await this.executeOneInstruction(tx.publicKey, ixPDA, additionalComputeBudgetInstruction);
                         } catch (_e) {
                             console.log("Error executing instruction, trying it again");
-                            await this.api.squads.getTransaction(tx.publicKey);
-                            const ix = await this.api.executeInstructionBuilder(tx.publicKey, ixPDA);
-                            const {blockhash, lastValidBlockHeight} = await this.api.connection.getLatestBlockhash();
-                            const executeIxTx = new Transaction({lastValidBlockHeight, blockhash, feePayer: this.wallet.publicKey});
-                            executeIxTx.add(additionalComputeBudgetInstruction, ix);
-                            const signed = await this.wallet.signTransaction(executeIxTx);
-                            const txid = await this.api.connection.sendRawTransaction(signed.serialize(), {skipPreflight: true});
-                            console.log(`ix ${ixIndex} retry signature: ${txid}`);
-                            await this.api.connection.confirmTransaction(txid, "confirmed");
+                            await this.executeOneInstruction(tx.publicKey, ixPDA, additionalComputeBudgetInstruction);
                         }
-                        await this.api.squads.getTransaction(tx.publicKey);
+                        // Confirm on-chain progress before counting this instruction:
+                        // a confirmed-but-failed send leaves executedIndex behind, and
+                        // we must not advance the loop (or the counter) past it.
+                        const refreshed = await this.api.squads.getTransaction(tx.publicKey);
+                        if (refreshed.executedIndex !== ixIndex) {
+                            throw new Error(`Execution stalled at instruction ${ixIndex}: on-chain executedIndex is ${refreshed.executedIndex}.`);
+                        }
                         successfullyExecuted++;
                     }
                 } else {
@@ -416,12 +427,19 @@ class Menu{
                     executeTx.add(additionalComputeBudgetInstruction, ix);
                     const signed = await this.wallet.signTransaction(executeTx);
                     const txid = await this.api.connection.sendRawTransaction(signed.serialize());
-                    await this.api.connection.confirmTransaction(txid, "processed");
+                    const result = await this.api.connection.confirmTransaction({signature: txid, blockhash, lastValidBlockHeight}, "confirmed");
+                    if (result.value.err) throw new Error(`Execution failed on chain: ${JSON.stringify(result.value.err)}`);
+                    successfullyExecuted = tx.instructionIndex - tx.executedIndex;
                 }
                 status.stop();
                 const updatedTx = await this.api.squads.getTransaction(tx.publicKey);
                 const newInd = txs.findIndex(t => t.publicKey.toBase58() === tx.publicKey.toBase58());
                 txs.splice(newInd, 1, updatedTx);
+                // Only claim full success once the on-chain transaction confirms every
+                // instruction ran; otherwise surface the partial prefix honestly.
+                if (updatedTx.executedIndex !== updatedTx.instructionIndex) {
+                    throw new Error(`Execution incomplete: ${updatedTx.executedIndex}/${updatedTx.instructionIndex} instructions executed on chain.`);
+                }
                 console.log("Transaction executed");
                 const updatedMs = await this.api.squads.getMultisig(ms.publicKey);
                 await continueInq();


### PR DESCRIPTION
This pull request refactors and improves the reliability of transaction execution in the `Menu` class, particularly around executing and confirming on-chain instructions. The main focus is to ensure that failures are reliably detected and that the code only advances when instructions are truly executed on-chain, preventing subtle bugs where failed instructions could be missed.

Key improvements and refactoring:

**Transaction execution reliability:**

* Introduced a new private method `executeOneInstruction` that builds, signs, sends, and confirms a single instruction transaction, explicitly checking for on-chain failures by inspecting the result's error field. This ensures that transaction failures are not missed due to the way websocket subscriptions resolve.
* Updated the instruction execution loop to use the new `executeOneInstruction` method for both initial attempts and retries, ensuring consistent error handling and confirmation logic.
* After each instruction execution, added a check to confirm that the on-chain `executedIndex` matches the expected instruction index, throwing an error and halting progress if execution has stalled. This prevents the loop from advancing past failed instructions.

**Final transaction confirmation:**

* Modified the final transaction confirmation to use the same robust error checking as individual instructions, and now throws if any error is detected in the confirmation result.
* Added a check after execution to ensure that all instructions have been executed on-chain before claiming success; otherwise, an error is thrown indicating how many instructions were actually executed.