### PR TITLE
fix(resume): partially executed transactions

### DIFF
--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -325,10 +325,15 @@ class Menu{
                 authority: authority.toBase58(),
                 approved: tx.approved.length,
                 rejected: tx.rejected.length,
-                instructions: tx.instructionIndex
+                instructions: tx.instructionIndex,
+                executed: tx.executedIndex,
+                remaining: tx.instructionIndex - tx.executedIndex,
             }
         ];
         console.table(txData);
+        if (tx.executedIndex > 0 && tx.executedIndex < tx.instructionIndex) {
+            console.log(chalk.yellow(`Partially executed: ${tx.executedIndex}/${tx.instructionIndex} instructions done — Execute will resume from instruction ${tx.executedIndex + 1}.`));
+        }
         if(tx.status.active){
             console.log(chalk.red("Be sure to review all transaction instructions before approving or executing!"));
         }
@@ -380,7 +385,14 @@ class Menu{
                 units: EXECUTE_IX_COMPUTE_UNIT_LIMIT,
             });
             try {
-                if (tx.instructionIndex > 3) {
+                // Drive the execute mode from transaction state, not just the raw
+                // instruction count. Once sequential execution has started
+                // (executedIndex > 0) the program rejects executeTransaction with
+                // PartialExecution (constraint: transaction.executed_index < 1), so
+                // a partially executed transaction of ANY size must continue via
+                // executeInstruction for the next PDA. The loop already resumes
+                // from executedIndex + 1.
+                if (tx.instructionIndex > 3 || tx.executedIndex > 0) {
                     for (let ixIndex = tx.executedIndex + 1; ixIndex <= tx.instructionIndex; ixIndex++) {
                         const [ixPDA] = getIxPDA(tx.publicKey, new anchor.BN(ixIndex), this.api.programId);
                         console.log("invoking instruction ", ixIndex);


### PR DESCRIPTION
This pull request enhances the transaction execution logic in `src/lib/menu.ts` by improving how partially executed transactions are handled and displayed. The changes ensure that the user interface and execution flow accurately reflect and support the state of transactions that have already had some instructions executed.

**Transaction status display improvements:**

* Added `executed` and `remaining` fields to the transaction summary output, allowing users to see how many instructions have been executed and how many remain. Also, a warning message is shown when a transaction is partially executed, indicating where execution will resume.

**Execution flow enhancements:**

* Updated the execution logic to allow continuing execution for any partially executed transaction, not just those with more than three instructions. The loop now resumes from the correct instruction index based on the transaction's state, ensuring proper handling of sequential execution and partial completion.